### PR TITLE
Use a constant ECOS_VERSION instead of recomputing version

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -140,7 +140,7 @@ struct Csettings
     centrality::Cdouble
 end
 
-if VersionNumber(ver()) >= v"2.0.5"
+if ECOS_VERSION >= v"2.0.5"
     @eval struct Cpwork
         # Dimensions
         n::Clong

--- a/test/direct.jl
+++ b/test/direct.jl
@@ -14,7 +14,7 @@ using Compat.SparseArrays
 # The values below are copied from data.h in ECOS source code
 import ECOS
 
-println(ECOS.ver())
+println(ECOS.ECOS_VERSION)
 
 function test1()
     n = 223

--- a/test/options.jl
+++ b/test/options.jl
@@ -10,7 +10,7 @@
 import ECOS
 using Compat.Test
 
-println(ECOS.ver())
+println(ECOS.ECOS_VERSION)
 
 n = 223
 m = 220


### PR DESCRIPTION
This moves the ECOS version from being recomputed via a `ccall` into the library on demand to a compile-time constant. This is may or may not help with the allocations noted in https://github.com/JuliaOpt/Convex.jl/issues/254#issuecomment-447860140, but at least it avoids having to recompute the version number.

It also adds a missing call to `check_deps` in `__init__`, which is recommended by all applications using BinaryProvider, and removes the note about Homebrew from the error message, as that is no longer relevant.