### PR TITLE
Skip build.jl on Julia 1.3+

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,3 +1,7 @@
+if VERSION >= v"1.3"
+    exit()  # Use ECOS_jll instead.
+end
+
 using BinaryProvider # requires BinaryProvider 0.3.0 or later
 
 # Parse some basic command-line arguments


### PR DESCRIPTION
Running the code in the build.jl became unnecessary with the changes made in https://github.com/jump-dev/ECOS.jl/pull/100 which just require ECOS_jll to be installed on Julia 1.3+.