### PR TITLE
Make package compatible with system images

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ julia> Pkg.add("ECOS")
 
 ECOS.jl will automatically install and setup the ECOS solver itself using [BinaryProvider.jl](https://github.com/JuliaPackaging/BinaryProvider.jl).
 
-## Custom Installation
-
-After ECOS.jl is installed and built, you can replace the installed binary dependencies with custom builds by overwritting the binaries and libraries in ECOS.jl's `deps/usr` folder (e.g. in Julia v0.6 `$HOME/.julia/v0.6/ECOS/deps/usr`).
-
-Note that the custom binaries will not be overwritten by subsequent builds of the currently installed version of ECOS.jl. However, if ECOS.jl is updated and the update includes new BinaryProvider versions of the ECOS binaries, then the custom binaries will be overwritten by the new BinaryProvider versions.
-
 ## Usage
 
 The ECOS interface is completely wrapped. ECOS functions corresponding to the C API are available as `ECOS.setup`, `ECOS.solve`, `ECOS.cleanup`, and `ECOS.ver` (these are not exported from the module). Function arguments are extensively documented in the source, and an example of usage can be found in `test/direct.jl`.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ julia> Pkg.add("ECOS")
 
 ECOS.jl will automatically install and setup the ECOS solver itself using [BinaryProvider.jl](https://github.com/JuliaPackaging/BinaryProvider.jl).
 
+## Custom Installation
+
+After ECOS.jl is installed and built, you can replace the installed `libecos` dependency with a custom installation by following the [Pkg documentation for overriding artifacts](https://julialang.github.io/Pkg.jl/v1/artifacts/#Overriding-artifact-locations-1). Note that your custom `libecos` is required to be at least version 2.0.5.
+
 ## Usage
 
 The ECOS interface is completely wrapped. ECOS functions corresponding to the C API are available as `ECOS.setup`, `ECOS.solve`, `ECOS.cleanup`, and `ECOS.ver` (these are not exported from the module). Function arguments are extensively documented in the source, and an example of usage can be found in `test/direct.jl`.

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -36,8 +36,8 @@ unsatisfied = any(!satisfied(p; verbose=verbose) for p in products)
 if haskey(download_info, platform_key())
     url, tarball_hash = download_info[platform_key()]
     # Check if this build.jl is providing new versions of the binaries, and
-    # if so, ovewrite the current binaries even if they were installed by the user 
-    if unsatisfied || !isinstalled(url, tarball_hash; prefix=prefix) 
+    # if so, ovewrite the current binaries even if they were installed by the user
+    if unsatisfied || !isinstalled(url, tarball_hash; prefix=prefix)
         # Download and install binaries
         install(url, tarball_hash; prefix=prefix, force=true, verbose=verbose)
     end

--- a/src/ECOS.jl
+++ b/src/ECOS.jl
@@ -40,14 +40,6 @@ macro ecos_ccall(func, args...)
     end
 end
 
-function __init__()
-    vnum = VersionNumber(ver())
-    if !(vnum.major == 2 && vnum.minor == 0)
-        depsdir = realpath(joinpath(dirname(@__FILE__),"..","deps"))
-        error("Current ECOS version installed is $(ver()), but we require version 2.0.*. On Linux and Windows, delete the contents of the `$depsdir` directory except for the files `build.jl` and `.gitignore`, then rerun Pkg.build(\"ECOS\"). On OS X, run `using Homebrew; Homebrew.update()` in Julia.")
-    end
-end
-
 include("types.jl")  # All the types and constants defined in ecos.h
 
 # A julia container for matrices passed to ECOS.

--- a/src/ECOS.jl
+++ b/src/ECOS.jl
@@ -44,6 +44,13 @@ macro ecos_ccall(func, args...)
     end
 end
 
+function __init__()
+    libecos_version = VersionNumber(ver())
+    if libecos_version < v"2.0.5"
+        error("Current ECOS version installed is $(ver()), but we require minimum version of 2.0.5")
+    end
+end
+
 include("types.jl")  # All the types and constants defined in ecos.h
 
 # A julia container for matrices passed to ECOS.

--- a/src/ECOS.jl
+++ b/src/ECOS.jl
@@ -25,6 +25,10 @@ else
 end
 # ver  [not exported]
 # Returns the version of ECOS in use
+#
+# Note: Avoid calling this function at the top-level as doing so breaks creating system
+# images which include this package
+# https://github.com/jump-dev/ECOS.jl/issues/106
 function ver()
     ver_ptr = ccall((:ECOS_ver, ECOS.ecos), Ptr{UInt8}, ())
     return unsafe_string(ver_ptr)

--- a/src/types.jl
+++ b/src/types.jl
@@ -140,178 +140,92 @@ struct Csettings
     centrality::Cdouble
 end
 
-if VersionNumber(ver()) >= v"2.0.5"
-    @eval struct Cpwork
-        # Dimensions
-        n::Clong
-        m::Clong
-        p::Clong
-        D::Clong
+# Note: Requires at least libecos version 2.0.5
+struct Cpwork
+    # Dimensions
+    n::Clong
+    m::Clong
+    p::Clong
+    D::Clong
 
-        # Variables
-        x::Ptr{Cdouble}
-        y::Ptr{Cdouble}
-        z::Ptr{Cdouble}
-        s::Ptr{Cdouble}
-        lambda::Ptr{Cdouble}
-        kap::Cdouble
-        tau::Cdouble
+    # Variables
+    x::Ptr{Cdouble}
+    y::Ptr{Cdouble}
+    z::Ptr{Cdouble}
+    s::Ptr{Cdouble}
+    lambda::Ptr{Cdouble}
+    kap::Cdouble
+    tau::Cdouble
 
-        # Best iterates seen so far
-        best_x::Ptr{Cdouble}
-        best_y::Ptr{Cdouble}
-        best_z::Ptr{Cdouble}
-        best_s::Ptr{Cdouble}
-        best_kap::Cdouble
-        best_tau::Cdouble
-        best_cx::Cdouble
-        best_by::Cdouble
-        best_hz::Cdouble
-        best_info::Ptr{Cstats}
+    # Best iterates seen so far
+    best_x::Ptr{Cdouble}
+    best_y::Ptr{Cdouble}
+    best_z::Ptr{Cdouble}
+    best_s::Ptr{Cdouble}
+    best_kap::Cdouble
+    best_tau::Cdouble
+    best_cx::Cdouble
+    best_by::Cdouble
+    best_hz::Cdouble
+    best_info::Ptr{Cstats}
 
-        # Temporary variables
-        dsaff::Ptr{Cdouble}
-        dzaff::Ptr{Cdouble}
-        W_times_dzaff::Ptr{Cdouble}
-        dsaff_by_W::Ptr{Cdouble}
-        saff::Ptr{Cdouble}
-        zaff::Ptr{Cdouble}
+    # Temporary variables
+    dsaff::Ptr{Cdouble}
+    dzaff::Ptr{Cdouble}
+    W_times_dzaff::Ptr{Cdouble}
+    dsaff_by_W::Ptr{Cdouble}
+    saff::Ptr{Cdouble}
+    zaff::Ptr{Cdouble}
 
-        # Cone
-        C::Ptr{Ccone}
-        A::Ptr{Cspmat}
-        G::Ptr{Cspmat}
-        c::Ptr{Cdouble}
-        b::Ptr{Cdouble}
-        h::Ptr{Cdouble}
+    # Cone
+    C::Ptr{Ccone}
+    A::Ptr{Cspmat}
+    G::Ptr{Cspmat}
+    c::Ptr{Cdouble}
+    b::Ptr{Cdouble}
+    h::Ptr{Cdouble}
 
-        # indices that map entries of A and G to the KKT matrix
-        AtoK::Ptr{Clong}
-        GtoK::Ptr{Clong}
+    # indices that map entries of A and G to the KKT matrix
+    AtoK::Ptr{Clong}
+    GtoK::Ptr{Clong}
 
-        # equilibration vector
-        xequil::Ptr{Cdouble}
-        Aequil::Ptr{Cdouble}
-        Gequil::Ptr{Cdouble}
+    # equilibration vector
+    xequil::Ptr{Cdouble}
+    Aequil::Ptr{Cdouble}
+    Gequil::Ptr{Cdouble}
 
-        # scalings of problem data
-        resx0::Cdouble
-        resy0::Cdouble
-        resz0::Cdouble
+    # scalings of problem data
+    resx0::Cdouble
+    resy0::Cdouble
+    resz0::Cdouble
 
-        # residuals
-        rx::Ptr{Cdouble}
-        ry::Ptr{Cdouble}
-        rz::Ptr{Cdouble}
-        rt::Cdouble
-        hresx::Cdouble
-        hresy::Cdouble
-        hresz::Cdouble
+    # residuals
+    rx::Ptr{Cdouble}
+    ry::Ptr{Cdouble}
+    rz::Ptr{Cdouble}
+    rt::Cdouble
+    hresx::Cdouble
+    hresy::Cdouble
+    hresz::Cdouble
 
-        # norm iterates
-        nx::Cdouble
-        ny::Cdouble
-        nz::Cdouble
-        ns::Cdouble
+    # norm iterates
+    nx::Cdouble
+    ny::Cdouble
+    nz::Cdouble
+    ns::Cdouble
 
-        # temporary storage
-        cx::Cdouble
-        by::Cdouble
-        hz::Cdouble
-        sz::Cdouble
+    # temporary storage
+    cx::Cdouble
+    by::Cdouble
+    hz::Cdouble
+    sz::Cdouble
 
-        # KKT System
-        KKT::Ptr{Ckkt}
+    # KKT System
+    KKT::Ptr{Ckkt}
 
-        # info struct
-        info::Ptr{Cstats}
+    # info struct
+    info::Ptr{Cstats}
 
-        # settings struct
-        stgs::Ptr{Csettings}
-    end
-else
-    @eval struct Cpwork
-        # Dimensions
-        n::Clong
-        m::Clong
-        p::Clong
-        D::Clong
-
-        # Variables
-        x::Ptr{Cdouble}
-        y::Ptr{Cdouble}
-        z::Ptr{Cdouble}
-        s::Ptr{Cdouble}
-        lambda::Ptr{Cdouble}
-        kap::Cdouble
-        tau::Cdouble
-
-        # Best iterates seen so far
-        best_x::Ptr{Cdouble}
-        best_y::Ptr{Cdouble}
-        best_z::Ptr{Cdouble}
-        best_s::Ptr{Cdouble}
-        best_kap::Cdouble
-        best_tau::Cdouble
-        best_cx::Cdouble
-        best_by::Cdouble
-        best_hz::Cdouble
-        best_info::Ptr{Cstats}
-
-        # Temporary variables
-        dsaff::Ptr{Cdouble}
-        dzaff::Ptr{Cdouble}
-        W_times_dzaff::Ptr{Cdouble}
-        dsaff_by_W::Ptr{Cdouble}
-        saff::Ptr{Cdouble}
-        zaff::Ptr{Cdouble}
-
-        # Cone
-        C::Ptr{Ccone}
-        A::Ptr{Cspmat}
-        G::Ptr{Cspmat}
-        c::Ptr{Cdouble}
-        b::Ptr{Cdouble}
-        h::Ptr{Cdouble}
-
-        # equilibration vector
-        xequil::Ptr{Cdouble}
-        Aequil::Ptr{Cdouble}
-        Gequil::Ptr{Cdouble}
-
-        # scalings of problem data
-        resx0::Cdouble
-        resy0::Cdouble
-        resz0::Cdouble
-
-        # residuals
-        rx::Ptr{Cdouble}
-        ry::Ptr{Cdouble}
-        rz::Ptr{Cdouble}
-        rt::Cdouble
-        hresx::Cdouble
-        hresy::Cdouble
-        hresz::Cdouble
-
-        # norm iterates
-        nx::Cdouble
-        ny::Cdouble
-        nz::Cdouble
-        ns::Cdouble
-
-        # temporary storage
-        cx::Cdouble
-        by::Cdouble
-        hz::Cdouble
-        sz::Cdouble
-
-        # KKT System
-        KKT::Ptr{Ckkt}
-
-        # info struct
-        info::Ptr{Cstats}
-
-        # settings struct
-        stgs::Ptr{Csettings}
-    end
+    # settings struct
+    stgs::Ptr{Csettings}
 end


### PR DESCRIPTION
As both `deps/build.jl` and the compat requirement for ECOS_jll enforce specify that libecos 2.0.5 we should be safe to drop any code to support older versions of libecos. In the future if ECOS.jl can support other versions of libecos this can be enforced by specifying the compat for ECOS_jll appropriately. 

Fixes: https://github.com/jump-dev/ECOS.jl/issues/106