### PR TITLE
Stop using Compat.Test (deprecated) + update travis badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ println(value.(take))
 [Convex.jl]: https://github.com/JuliaOpt/Convex.jl
 [Homebrew.jl]: https://github.com/JuliaLang/Homebrew.jl
 
-[build-img]: https://travis-ci.org/jump-dev/ECOS.jl.svg?branch=master
-[build-url]: https://travis-ci.org/jump-dev/ECOS.jl
+[build-img]: https://travis-ci.com/jump-dev/ECOS.jl.svg?branch=master
+[build-url]: https://travis-ci.com/jump-dev/ECOS.jl
 [winbuild-img]: https://ci.appveyor.com/api/projects/status/n0c8b6t1w39jho6d/branch/master?svg=true
 [winbuild-url]: https://ci.appveyor.com/project/JuliaOpt/ecos-jl/branch/master
 [coveralls-img]: https://coveralls.io/repos/github/jump-dev/ECOS.jl/badge.svg?branch=master

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,7 @@
 
 using ECOS
 
-using Compat
-using Compat.Test
+using Test
 
 @testset "Test the direct interface" begin
     include("direct.jl")


### PR DESCRIPTION
- Replacing `Compat.Test` with `Test` as per deprecation warning (tested on julia 1.0 and 1.5)
- Update travis badge links to use travis-ci.com instead of travis-ci.org (current links go through an extra redirect page)