### PR TITLE
Fix numerical issue in primal infeasibility certificates

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -266,7 +266,7 @@ function _optimize!(dest::Optimizer, src::OptimizerCache)
     if MOI.Utilities.is_ray(MOI.get(dest, MOI.DualStatus()))
         # ECOS can return very large rays here! Without this rescaling it fails
         # many of the MOI tests due to rounding error in floating-point.
-        len = sqrt(sum(dest.sol.dual_ineq.^2) + sum(dest.sol.dual_eq.^2))
+        len = sqrt(sum(dest.sol.dual_ineq .^ 2) + sum(dest.sol.dual_eq .^ 2))
         dest.sol.dual_ineq ./= len
         dest.sol.dual_eq ./= len
         dest.sol.dual_objective_value /= len


### PR DESCRIPTION
Needed to pass the upcoming tests in MOI 0.10.6:
https://github.com/jump-dev/SolverTests/pull/17

Passing on my local machine:
```julia
 1  -3.000e+00  -4.309e+00  +2e+00  6e-02  5e-02  3e-01  5e-01  0.8642  3e-03   1  1  1 |  0  0
 2  -3.000e+00  +8.743e+00  +3e-01  3e+00  4e-01  4e+01  9e-02  0.9400  1e-01   1  1  1 |  0  0
 3  -3.000e+00  +3.614e+03  +4e-03  3e+00  4e-01  4e+03  1e-03  0.9886  1e-04   1  1  1 |  0  0
 4  -2.999e+00  +2.685e+05  +4e-05  2e+00  3e-01  3e+05  1e-05  0.9890  1e-04   1  1  1 |  0  0
 5  -2.999e+00  +2.067e+07  +5e-07  2e+00  3e-01  2e+07  1e-07  0.9890  1e-04   2  0  0 |  0  0

PRIMAL INFEASIBLE (within feastol=4.8e-09).
Runtime: 0.000076 seconds.

Test Summary:             | Pass  Total
Test the direct interface |    3      3
WARNING: replacing module TestECOS.
Test Summary:    | Pass  Total
MathOptInterface | 2501   2501
Test.DefaultTestSet("MathOptInterface", Any[Test.DefaultTestSet("test_RawOptimizerAttribute", Any[], 2, false, false), Test.DefaultTestSet("test_iteration_limit", Any[], 2, false, false), Test.DefaultTestSet("test_runtests", Any[Test.DefaultTestSet("test_add_constrained_variables_vector", Any[], 6, false, false), Test.DefaultTestSet("test_attribute_NumberThreads", Any[], 0, false, false), Test.DefaultTestSet("test_attribute_RawStatusString", Any[], 1, false, false), Test.DefaultTestSet("test_attribute_Silent", Any[], 4, false, false), Test.DefaultTestSet("test_attribute_SolveTimeSec", Any[], 2, false, false), Test.DefaultTestSet("test_attribute_SolverName", Any[], 1, false, false), Test.DefaultTestSet("test_attribute_SolverVersion", Any[], 1, false, false), Test.DefaultTestSet("test_attribute_TimeLimitSec", Any[], 0, false, false), Test.DefaultTestSet("test_attribute_after_empty", Any[], 4, false, false), Test.DefaultTestSet("test_basic_ScalarAffineFunction_EqualTo", Any[], 23, false, false)  …  Test.DefaultTestSet("test_variable_delete_Nonnegatives_row", Any[], 12, false, false), Test.DefaultTestSet("test_variable_delete_SecondOrderCone", Any[], 10, false, false), Test.DefaultTestSet("test_variable_delete_variables", Any[], 9, false, false), Test.DefaultTestSet("test_variable_get_VariableIndex", Any[], 2, false, false), Test.DefaultTestSet("test_variable_solve_Integer_with_lower_bound", Any[], 0, false, false), Test.DefaultTestSet("test_variable_solve_Integer_with_upper_bound", Any[], 0, false, false), Test.DefaultTestSet("test_variable_solve_ZeroOne_with_0_upper_bound", Any[], 0, false, false), Test.DefaultTestSet("test_variable_solve_ZeroOne_with_upper_bound", Any[], 0, false, false), Test.DefaultTestSet("test_variable_solve_with_lowerbound", Any[], 10, false, false), Test.DefaultTestSet("test_variable_solve_with_upperbound", Any[], 12, false, false)], 0, false, false)], 0, false, false)

(ECOS) pkg> st
     Project ECOS v0.14.0
      Status `~/.julia/dev/ECOS/Project.toml`
  [fa961155] CEnum v0.4.1
  [b8f27783] MathOptInterface v0.10.5 `https://github.com/jump-dev/MathOptInterface.jl.git#master`
  [c2c64177] ECOS_jll v2.0.8+1
```