### PR TITLE
Fix return type of ListOfNonstandardBridges

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -118,7 +118,7 @@ function MOI.empty!(optimizer::Optimizer)
 end
 
 function MOI.get(::Optimizer, ::MOI.Bridges.ListOfNonstandardBridges)
-    return [PermutedExponentialBridge{pfloat}]
+    return Type[PermutedExponentialBridge{pfloat}]
 end
 
 function _rows(


### PR DESCRIPTION
This is now checked
https://github.com/jump-dev/MathOptInterface.jl/pull/2665
so the tests of ECOS are now failing