### PR TITLE
Use regex for tests

### DIFF
--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -82,7 +82,7 @@ function test_runtests_ZerosBridge()
                 MOI.ObjectiveBound,
             ],
         ),
-        include = String[
+        include = [
             # ZerosBridge does not support ConstraintDual
             r"test_conic_RotatedSecondOrderCone_INFEASIBLE_2",
             r"test_conic_linear_VectorOfVariables_2",

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -30,7 +30,7 @@ function test_runtests()
     @test model.optimizer.model.model_cache isa
           MOI.Utilities.UniversalFallback{ECOS.OptimizerCache}
     MOI.set(model, MOI.Silent(), true)
-    exclude = String[
+    exclude = [
         # ZerosBridge does not support ConstraintDual. These are tested below in
         # test_runtests_ZerosBridge
         r"test_conic_RotatedSecondOrderCone_INFEASIBLE_2$",

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -42,8 +42,8 @@ function test_runtests()
     if Sys.WORD_SIZE == 32
         # These tests fail on x86 Linux, returning ITERATION_LIMIT instead of
         # proving {primal,dual}_INFEASIBLE.
-        push!(exclude, "test_conic_linear_INFEASIBLE")
-        push!(exclude, "test_solve_TerminationStatus_DUAL_INFEASIBLE")
+        push!(exclude, r"test_conic_linear_INFEASIBLE$")
+        push!(exclude, r"test_solve_TerminationStatus_DUAL_INFEASIBLE$")
     end
     MOI.Test.runtests(
         model,
@@ -84,11 +84,11 @@ function test_runtests_ZerosBridge()
         ),
         include = String[
             # ZerosBridge does not support ConstraintDual
-            "test_conic_RotatedSecondOrderCone_INFEASIBLE_2",
-            "test_conic_linear_VectorOfVariables_2",
-            "test_linear_integration",
-            "test_quadratic_constraint_GreaterThan",
-            "test_quadratic_constraint_LessThan",
+            r"test_conic_RotatedSecondOrderCone_INFEASIBLE_2",
+            r"test_conic_linear_VectorOfVariables_2",
+            r"test_linear_integration",
+            r"test_quadratic_constraint_GreaterThan",
+            r"test_quadratic_constraint_LessThan",
         ],
     )
     return

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -33,11 +33,11 @@ function test_runtests()
     exclude = String[
         # ZerosBridge does not support ConstraintDual. These are tested below in
         # test_runtests_ZerosBridge
-        "test_conic_RotatedSecondOrderCone_INFEASIBLE_2",
-        "test_conic_linear_VectorOfVariables_2",
-        "test_linear_integration",
-        "test_quadratic_constraint_GreaterThan",
-        "test_quadratic_constraint_LessThan",
+        r"test_conic_RotatedSecondOrderCone_INFEASIBLE_2$",
+        r"test_conic_linear_VectorOfVariables_2$",
+        r"test_linear_integration$",
+        r"test_quadratic_constraint_GreaterThan$",
+        r"test_quadratic_constraint_LessThan$",
     ]
     if Sys.WORD_SIZE == 32
         # These tests fail on x86 Linux, returning ITERATION_LIMIT instead of


### PR DESCRIPTION
Fixes a warning that is currently displayed
```julia
┌ Warning: The exclude string "test_linear_integration" is ambiguous because it exactly matches a test, but it also partially matches another. Use `r"^test_linear_integration$"` to exclude the exactly matching test, or `r"test_linear_integration.*"` to exclude all partially matching tests.
└ @ MathOptInterface.Test ~/.julia/packages/MathOptInterface/yI6C0/src/Test/Test.jl:237
```